### PR TITLE
Fix: gemini 2.0 flash experimental being discontinued

### DIFF
--- a/app/api/route.ts
+++ b/app/api/route.ts
@@ -12,7 +12,7 @@ const retrieveTranslation = async (text: string, language: string) => {
 	while (retries > 0) {
 		try {
 			const { text: translatedText } = await generateText({
-				model: google("gemini-2.0-flash-exp"),
+				model: google("gemini-2.5-flash-lite"),
 				messages: [
 					{
 						role: "system",


### PR DESCRIPTION
I was trying to use the project in order to translate some subtitles but I got an error in the logs when trying to run it locally with a gemini api key. The problem was that the model used (`gemini-2.0-flash-exp`) was no longer available, so I changed it to the model Google recommends switching to (`gemini-2.5-flash-lite`).