### PR TITLE
Fix subtitle desync, timestamp crash, Firefox button, Portuguese variants

### DIFF
--- a/app/api/route.ts
+++ b/app/api/route.ts
@@ -7,7 +7,7 @@ export const dynamic = "force-dynamic";
 
 const MAX_TOKENS_IN_SEGMENT = 700;
 
-const retrieveTranslation = async (text: string, language: string) => {
+const retrieveTranslation = async (text: string, language: string, expectedCount: number) => {
 	let retries = 3;
 	while (retries > 0) {
 		try {
@@ -17,11 +17,15 @@ const retrieveTranslation = async (text: string, language: string) => {
 					{
 						role: "system",
 						content:
-							"You are an experienced semantic translator, specialized in creating SRT files. Separate translation segments with the '|' symbol",
+							"You are an experienced semantic translator for SRT subtitle files. CRITICAL RULES:\n" +
+							"1. Separate each translated segment with the '|' symbol.\n" +
+							"2. You MUST output EXACTLY the same number of segments as the input. Do NOT merge or split segments.\n" +
+							"3. Each input segment separated by '|' must produce exactly one output segment separated by '|'.\n" +
+							"4. Preserve the one-to-one mapping between input and output segments.",
 					},
 					{
 						role: "user",
-						content: `Translate this to ${language}: ${text}`,
+						content: `Translate these ${expectedCount} subtitle segments to ${language}. Output exactly ${expectedCount} segments separated by '|':\n${text}`,
 					},
 				],
 			});
@@ -53,16 +57,17 @@ export async function POST(request: Request) {
 			async start(controller) {
 				for (const group of groups) {
 					const text = group.map((segment) => segment.text).join("|");
-					const translatedText = await retrieveTranslation(text, language);
+					const translatedText = await retrieveTranslation(text, language, group.length);
 					if (!translatedText) continue;
 
-					const translatedSegments = translatedText.split("|");
-					for (const segment of translatedSegments) {
-						if (segment.trim()) {
-							const originalSegment = segments[currentIndex];
-							const srt = `${++currentIndex}\n${originalSegment?.timestamp || ""}\n${segment.trim()}\n\n`;
-							controller.enqueue(encoder.encode(srt));
-						}
+					const translatedSegments = translatedText.split("|").map(s => s.trim()).filter(Boolean);
+
+					// Ensure 1:1 mapping: pad or truncate to match original group size
+					for (let i = 0; i < group.length; i++) {
+						const originalSegment = segments[currentIndex];
+						const translated = translatedSegments[i] || originalSegment?.text || "";
+						const srt = `${++currentIndex}\n${originalSegment?.timestamp || ""}\n${translated}\n\n`;
+						controller.enqueue(encoder.encode(srt));
 					}
 				}
 				controller.close();

--- a/components/Form.tsx
+++ b/components/Form.tsx
@@ -11,7 +11,7 @@ function classNames(...classes: any[]) {
 }
 
 const LANGUAGES = [
-  'Traditional Chinese', 'Simplified Chinese', 'Spanish', 'English', 'Hindi', 'Bengali', 'Portuguese', 'Russian',
+  'Traditional Chinese', 'Simplified Chinese', 'Spanish', 'English', 'Hindi', 'Bengali', 'Portuguese (Brazil)', 'Portuguese (Portugal)', 'Russian',
   'Japanese', 'Punjabi', 'Marathi', 'Telugu', 'Wu Chinese', 'Turkish', 'Korean',
   'French', 'German', 'Vietnamese', 'Tamil', 'Yue Chinese', 'Urdu', 'Javanese', 'Italian', 'Icelandic',
   'Arabic', 'Gujarati', 'Persian', 'Bhojpuri', 'Min Nan', 'Hakka',
@@ -103,7 +103,7 @@ const SrtForm: React.FC<Props> = ({ onSubmit }) => {
           type="file"
           accept=".srt"
           onChange={(e) => setFile(e.target.files![0])}
-          className="absolute inset-0 opacity-0 cursor-pointer"
+          className="absolute inset-0 z-10 opacity-0 cursor-pointer"
         />
         <div
           className={classNames(

--- a/components/Timestamp.tsx
+++ b/components/Timestamp.tsx
@@ -10,10 +10,12 @@ const Timestamp: FC<Chunk & { originalText?: string }> = ({
 	originalText,
 }) => {
 	const formatTimestamp = (timestamp: string) => {
-		let [hours, minutes, secondsWithMs] = timestamp.split(":");
-		const [seconds, ms] = secondsWithMs.split(",");
-
-		return `${minutes}:${seconds}.${ms[0]}`;
+		if (!timestamp) return "0:00.0";
+		const parts = timestamp.split(":");
+		if (parts.length < 3) return timestamp;
+		const [hours, minutes, secondsWithMs] = parts;
+		const [seconds, ms] = (secondsWithMs || "0,0").split(",");
+		return `${minutes}:${seconds}.${(ms || "0")[0]}`;
 	};
 
 	return (


### PR DESCRIPTION
## Summary

Batch fix for multiple open issues:

- **Fix #49 / #46 (Subtitle Desync)**: The LLM was merging/splitting subtitle segments during translation, causing timing misalignment. Fixed with a stricter prompt enforcing 1:1 segment mapping + post-processing that always emits exactly as many segments as the original, falling back to untranslated text if the LLM returns fewer.
- **Fix #47 (Timestamp Crash)**: `formatTimestamp` in `Timestamp.tsx` crashed on undefined/malformed timestamps. Added null checks and fallbacks.
- **Fix #26 (Firefox Browse Button)**: The hidden file input was behind other elements in Firefox due to missing z-index. Added `z-10` class.
- **Fix #48 (Portuguese Variants)**: Replaced generic "Portuguese" with "Portuguese (Brazil)" and "Portuguese (Portugal)".

Also closed #30 (Docker — already merged in PR #31) and #19 (Node v12 install failure — resolved by Docker support).

## Test plan
- [ ] Upload an SRT file and translate — verify output has same number of segments as input
- [ ] Test with Japanese → English to verify desync fix
- [ ] Open in Firefox and verify "Browse for SRT file" button works
- [ ] Verify Portuguese (Brazil) and Portuguese (Portugal) appear in language dropdown
- [ ] Upload a malformed SRT file — verify no crash on timestamp display